### PR TITLE
[+1] Casting the difference in days to an integer

### DIFF
--- a/js/daterangepicker.jQuery.js
+++ b/js/daterangepicker.jQuery.js
@@ -94,7 +94,7 @@
                     // Check if the number of selected days is out of allowed range.
                     if (!_.isUndefined(options.maximumNumberOfDays) && options.maximumNumberOfDays > 0) {
                         var duration = moment.duration(moment(datePickerB).diff(moment(datePickerA)));
-                        var dateDiff = duration.asDays();
+                        var dateDiff = parseInt(duration.asDays());
 
                         if (dateDiff > options.maximumNumberOfDays) {
                             errorMessageOutOfRange.show();


### PR DESCRIPTION
Daylight savings makes the difference in days ~31.04
Casting the value to an int will give users a few more hours, so they don't get the warning message.

https://blacklinegps.atlassian.net/browse/SW-10475